### PR TITLE
docs(vercel): add quick setup steps for frontend deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ python manage.py createsuperuser
 - Frontend: Vercel or Netlify (free)
 - See docs/DEPLOYMENT.md for step-by-step
 
+### Vercel (frontend) quick setup
+
+1. Import this repo in Vercel → select Root Directory: `frontend/`.
+2. Framework: Create React App (auto-detected). Node.js Version: 18.x.
+3. Build Command: `npm run build` • Output Directory: `build`.
+4. Env var: `REACT_APP_API_BASE=https://trip-viser.onrender.com/api/v1`.
+5. Deploy, then add your Vercel origin to backend `CORS_ALLOWED_ORIGINS` (Render).
+6. Optional: set `FRONTEND_URL` on the backend so GET `/` redirects to the UI.
+
 ### Render (backend) environment
 
 Set these environment variables in your Render Web Service:


### PR DESCRIPTION
## Summary

Adds a short Vercel deployment checklist for the frontend:
Select Root Directory: frontend/
CRA preset, Node 18, build to build/
Set REACT_APP_API_BASE to the Render API URL
Add Vercel origin to backend CORS and optionally FRONTEND_URL
No code changes; documentation only.

## Changes

-
-

## Screenshots / Demos (optional)

## Tests

- [ ] Backend tests pass (CI)
- [ ] Frontend build passes (CI)
- [ ] Added/updated tests where meaningful

## Checklist

- [ ] Docs updated (README/docs/*) if behavior changed
- [ ] Linked issues (e.g., closes #123)
- [ ] No secrets / keys committed
2025-09-20
