### PR TITLE
deploy: align vercel rewrite and render envs; document no-shell seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ python manage.py createsuperuser
 1. Import this repo in Vercel → select Root Directory: `frontend/`.
 2. Framework: Create React App (auto-detected). Node.js Version: 18.x.
 3. Build Command: `npm run build` • Output Directory: `build`.
-4. Env var: `REACT_APP_API_BASE=https://trip-viser.onrender.com/api/v1`.
+4. No env vars required: `frontend/vercel.json` includes a rewrite that proxies `/api/*` to the Render backend.
 5. Deploy, then add your Vercel origin to backend `CORS_ALLOWED_ORIGINS` (Render).
 6. Optional: set `FRONTEND_URL` on the backend so GET `/` redirects to the UI.
 
@@ -103,6 +103,16 @@ Root path behavior:
 
 - `GET /` serves a minimal landing page with links to `/api/health/`, `/api/schema/`, and `/admin/`.
 - If `FRONTEND_URL` is set, `GET /` redirects to that URL (recommended when frontend is hosted on Vercel/Netlify).
+
+### Seeding demo data on Render (no shell access)
+
+If you cannot access Render Shell, you can trigger seeding during deploys:
+
+1. In Render → Environment → add `SEED_DEMO=true` (temporarily).
+2. Redeploy. During build, the service will run `python backend/seed_sample_data.py` and create:
+	- 3 supervisors: `supervisor1..3` (password `Test@1234`)
+	- 20 drivers: `driver1..20` (password `Test@1234`)
+3. Remove `SEED_DEMO` or set it to `false` after seeding to avoid re-running on future deploys.
 
 ## License
 

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -3,5 +3,11 @@
   "version": 2,
   "framework": "create-react-app",
   "buildCommand": "npm run build",
-  "outputDirectory": "build"
+  "outputDirectory": "build",
+  "rewrites": [
+    {
+      "source": "/api/(.*)",
+      "destination": "https://trip-viser.onrender.com/api/$1"
+    }
+  ]
 }

--- a/render.yaml
+++ b/render.yaml
@@ -9,6 +9,10 @@ services:
       pip install -r requirements.txt
       python manage.py collectstatic --noinput
       python manage.py migrate --noinput
+      # Optionally seed demo data (3 supervisors, 20 drivers) when SEED_DEMO=true
+      if [ "$SEED_DEMO" = "true" ]; then
+        python backend/seed_sample_data.py
+      fi
     startCommand: gunicorn backend.wsgi:application --bind 0.0.0.0:$PORT
     envVars:
       - key: SECRET_KEY
@@ -16,8 +20,8 @@ services:
       - key: DEBUG
         value: "false"
       - key: ALLOWED_HOSTS
-        value: "trip-viser-backend.onrender.com"
+        value: "trip-viser.onrender.com"
       - key: DATABASE_URL
         sync: false
       - key: CORS_ALLOWED_ORIGINS
-        value: "https://trip-viser-frontend.vercel.app"
+        value: "https://trip-viser.vercel.app"


### PR DESCRIPTION
## Summary

- Align frontend → backend integration in production by proxying /api/* from Vercel to the Render backend.
- Ensure Render envs match the live domains.
- Document one-click demo data seeding when shell access isn’t available

## Changes

- vercel.json
- Add rewrites to proxy /api/* → https://trip-viser.onrender.com/api/$1
- render.yaml
- ALLOWED_HOSTS=trip-viser.onrender.com
- CORS_ALLOWED_ORIGINS=https://trip-viser.vercel.app
- README.md
- Add “Seeding demo data on Render (no shell access)” with SEED_DEMO=true
- Clarify Vercel setup (no REACT_APP_API_BASE needed due to rewrites)

## Screenshots / Demos (optional)

## Tests

- [ ] Backend tests pass (CI)
- [ ] Frontend build passes (CI)
- [ ] Added/updated tests where meaningful

## Checklist

- [ ] Docs updated (README/docs/*) if behavior changed
- [ ] Linked issues (e.g., closes #123)
- [ ] No secrets / keys committed
2025-09-20
