### PR TITLE
Chore/seed 23 demo users

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -175,19 +175,27 @@ else:
 LEADERBOARD_CACHE_TTL = int(os.getenv('LEADERBOARD_CACHE_TTL', '120'))
 
 # CORS configuration
+from corsheaders.defaults import default_headers, default_methods
 # In hosted environments, set CORS_ALLOWED_ORIGINS to the exact frontend origins (comma-separated)
 CORS_ALLOWED_ORIGINS = [o.strip() for o in os.getenv('CORS_ALLOWED_ORIGINS', '').split(',') if o.strip()]
 CORS_ALLOW_CREDENTIALS = True
+CORS_ALLOW_HEADERS = list(default_headers) + [
+    'authorization',
+    'content-type',
+]
+CORS_ALLOW_METHODS = list(default_methods)
 
-# Developer-friendly defaults: when DEBUG and no explicit CORS origins are provided,
-# allow common localhost origins to simplify local dev across ports.
-if DEBUG and not CORS_ALLOWED_ORIGINS:
-    CORS_ALLOWED_ORIGINS = [
-        'http://localhost:3000',
-        'http://localhost:3001',
-        'http://127.0.0.1:3000',
-        'http://127.0.0.1:3001',
-    ]
+# Developer-friendly defaults: when DEBUG, allow all origins to simplify local dev across ports.
+if DEBUG:
+    CORS_ALLOW_ALL_ORIGINS = True
+    # For reference, these are common local origins (not required when allow-all is true)
+    if not CORS_ALLOWED_ORIGINS:
+        CORS_ALLOWED_ORIGINS = [
+            'http://localhost:3000',
+            'http://localhost:3001',
+            'http://127.0.0.1:3000',
+            'http://127.0.0.1:3001',
+        ]
 
 # CSRF trusted origins (mainly relevant if you enable cookie-based auth)
 CSRF_TRUSTED_ORIGINS = [o.replace('http://', 'http://').replace('https://', 'https://') for o in CORS_ALLOWED_ORIGINS]

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -175,10 +175,22 @@ else:
 LEADERBOARD_CACHE_TTL = int(os.getenv('LEADERBOARD_CACHE_TTL', '120'))
 
 # CORS configuration
-CORS_ALLOWED_ORIGINS = [
-    o.strip() for o in os.getenv('CORS_ALLOWED_ORIGINS', '').split(',') if o.strip()
-]
+# In hosted environments, set CORS_ALLOWED_ORIGINS to the exact frontend origins (comma-separated)
+CORS_ALLOWED_ORIGINS = [o.strip() for o in os.getenv('CORS_ALLOWED_ORIGINS', '').split(',') if o.strip()]
 CORS_ALLOW_CREDENTIALS = True
+
+# Developer-friendly defaults: when DEBUG and no explicit CORS origins are provided,
+# allow common localhost origins to simplify local dev across ports.
+if DEBUG and not CORS_ALLOWED_ORIGINS:
+    CORS_ALLOWED_ORIGINS = [
+        'http://localhost:3000',
+        'http://localhost:3001',
+        'http://127.0.0.1:3000',
+        'http://127.0.0.1:3001',
+    ]
+
+# CSRF trusted origins (mainly relevant if you enable cookie-based auth)
+CSRF_TRUSTED_ORIGINS = [o.replace('http://', 'http://').replace('https://', 'https://') for o in CORS_ALLOWED_ORIGINS]
 
 # Security headers (effective when DEBUG is False)
 if not DEBUG:

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -90,8 +90,18 @@ export async function getELDLogsByUsername(username, limit = 5, page, pageSize, 
 }
 
 // --- Auth helpers ---
-// Allow overriding the API base (e.g., point to live backend) via env var
-const API_BASE = process.env.REACT_APP_API_BASE || '';
+// API base resolution:
+// 1) If REACT_APP_API_BASE is provided, use it.
+// 2) Otherwise, when running locally on localhost/127.0.0.1, default to the Django dev server at 127.0.0.1:8000.
+// 3) Otherwise, leave blank and rely on reverse-proxy rewrites (e.g., Vercel vercel.json) or same-origin.
+const ENV_API_BASE = process.env.REACT_APP_API_BASE;
+let API_BASE = ENV_API_BASE || '';
+if (!API_BASE && typeof window !== 'undefined') {
+  const host = window.location.hostname;
+  if (host === 'localhost' || host === '127.0.0.1') {
+    API_BASE = 'http://127.0.0.1:8000';
+  }
+}
 const withBase = (url) => (API_BASE && url.startsWith('/')) ? `${API_BASE}${url}` : url;
 let accessToken = (typeof window !== 'undefined' && window.localStorage) ? window.localStorage.getItem('accessToken') : null;
 export function setAccessToken(token) {


### PR DESCRIPTION
## Summary

- Adds management command seed_demo to create/ensure exactly 23 demo users:
- Supervisors: supervisor1..3 (staff+superuser, role=supervisor) — password Test@1234
- Drivers: driver1..20 (role=driver) — password Test@1234
- Improves CORS behavior for local development:
- In DEBUG: allow all origins (CORS_ALLOW_ALL_ORIGINS=True)
- Explicitly allow common headers/methods and set CSRF_TRUSTED_ORIGINS
- Frontend API base:
- Auto-detect http://127.0.0.1:8000 when running locally if REACT_APP_API_BASE isn’t set
- Hosted continues to work with REACT_APP_API_BASE or vercel.json rewrites

## Screenshots / Demos (optional)

## Tests

- [x] Backend tests pass (CI)
- [ ] Frontend build passes (CI)
- [x] Added/updated tests where meaningful

## Checklist

- [x] Docs updated (README/docs/*) if behavior changed
- [x] Linked issues (e.g., closes #123)
- [x] No secrets / keys committed
2025-09-20
