### PR TITLE
Chore/seed 23 demo users

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Full-stack app for trip routing and ELD log visualization.
 - Versioned API: /api/v1
  - Mobile-friendly UI with responsive navbar and tables
 
+Demo video:
+- Watch on Loom: https://www.loom.com/share/e47c6ea5b1014472a3d86b6fb52dc0aa?sid=106d0a04-3d3f-4da7-9bd9-5fd8d6590858
+
 ## Features
 - Trip submission with route polyline
 - ELD log submission with accept/complete workflow

--- a/backend/seed_sample_data.py
+++ b/backend/seed_sample_data.py
@@ -14,7 +14,54 @@ django.setup()
 
 from backend.models import User, Driver, Supervisor
 from django.db import transaction
+from typing import Dict
 
+"""
+Seed/ensure demo supervisors and drivers using small template helpers
+so the structure is consistent and easy to tweak.
+"""
+
+# Prefer role constants on the User model if available; fallback to literals
+ROLE_SUPERVISOR = getattr(User, 'ROLE_SUPERVISOR', 'supervisor')
+ROLE_DRIVER = getattr(User, 'ROLE_DRIVER', 'driver')
+
+
+def supervisor_defaults(i: int, email: str) -> Dict[str, str]:
+    return {
+        'office': f'Office {i}',
+        'email': email,
+    }
+
+
+def driver_defaults(i: int, supervisor: Supervisor) -> Dict[str, object]:
+    # Rotate a simple status pattern: 0 -> Active, 1 -> Resting, 2 -> Off Duty
+    mod = i % 3
+    if mod == 0:
+        status = 'Active'
+    elif mod == 1:
+        status = 'Resting'
+    else:
+        status = 'Off Duty'
+
+    mileage = 1000 + i * 50
+    cycle_used = (i * 3) % 70
+    trips_today = (i % 5) + 1
+    phone = f'(555) 123-{1000 + i:04d}'
+    recent_trips = [f'Trip #{1200 + i - j} - 9/{18 - j}/2025' for j in range(3)]
+
+    return {
+        'license': f'DRV{i:03d}',
+        'truck': f'Truck{i}',
+        'trailer': f'Trailer{i}',
+        'office': supervisor.office,
+        'terminal': f'Terminal{i % 3 + 1}',
+        'status': status,
+        'mileage': mileage,
+        'cycleUsed': cycle_used,
+        'tripsToday': trips_today,
+        'phone': phone,
+        'recentTrips': recent_trips,
+    }
 
 
 def seed_supervisors():
@@ -35,18 +82,25 @@ def seed_supervisors():
             if not user.is_superuser:
                 user.is_superuser = True
                 changed = True
-            if user.role != 'supervisor':
-                user.role = 'supervisor'
+            if getattr(user, 'role', None) != ROLE_SUPERVISOR:
+                user.role = ROLE_SUPERVISOR
                 changed = True
             if changed:
                 user.save(update_fields=['is_staff', 'is_superuser', 'role'])
-        supervisor, _ = Supervisor.objects.get_or_create(
+        defaults = supervisor_defaults(i, email)
+        supervisor, created = Supervisor.objects.get_or_create(
             user=user,
-            defaults={
-                'office': f'Office {i}',
-                'email': email
-            }
+            defaults=defaults,
         )
+        # If already existed, lightly ensure defaults (idempotent updates)
+        if not created:
+            updates = {}
+            for k, v in defaults.items():
+                if getattr(supervisor, k, None) != v:
+                    setattr(supervisor, k, v)
+                    updates[k] = v
+            if updates:
+                supervisor.save(update_fields=list(updates.keys()))
         supervisors.append(supervisor)
     return supervisors
 
@@ -57,30 +111,31 @@ def seed_drivers(supervisors):
         # Use custom manager to create driver with correct permissions
         user = User.objects.filter(username=username).first()
         if not user:
-            user = User.objects.create_user(username=username, email=email, password='Test@1234', role='driver')
+            user = User.objects.create_user(
+                username=username,
+                email=email,
+                password='Test@1234',
+                role=ROLE_DRIVER,
+            )
+        elif getattr(user, 'role', None) != ROLE_DRIVER:
+            # Keep demo data consistent if role was altered
+            user.role = ROLE_DRIVER
+            user.save(update_fields=['role'])
+
         supervisor = supervisors[(i - 1) % len(supervisors)]
-        mileage = 1000 + i * 50
-        cycle_used = (i * 3) % 70
-        trips_today = i % 5 + 1
-        status = 'Active' if i % 3 != 0 else 'Resting' if i % 3 == 1 else 'Off Duty'
-        phone = f'(555) 123-{1000+i:04d}'
-        recent_trips = [f'Trip #{1200+i-j} - 9/{18-j}/2025' for j in range(3)]
-        Driver.objects.get_or_create(
+        defaults = driver_defaults(i, supervisor)
+        driver, created = Driver.objects.get_or_create(
             user=user,
-            defaults={
-                'license': f'DRV{i:03d}',
-                'truck': f'Truck{i}',
-                'trailer': f'Trailer{i}',
-                'office': supervisor.office,
-                'terminal': f'Terminal{i%3+1}',
-                'status': status,
-                'mileage': mileage,
-                'cycleUsed': cycle_used,
-                'tripsToday': trips_today,
-                'phone': phone,
-                'recentTrips': recent_trips,
-            }
+            defaults=defaults,
         )
+        if not created:
+            updates = {}
+            for k, v in defaults.items():
+                if getattr(driver, k, None) != v:
+                    setattr(driver, k, v)
+                    updates[k] = v
+            if updates:
+                driver.save(update_fields=list(updates.keys()))
 
 if __name__ == '__main__':
     with transaction.atomic():

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -5,6 +5,9 @@
 - Uses react-router-dom, react-leaflet for map, and auth-aware API client
  - Mobile-responsive UI and navbar (hamburger on small screens)
 
+Demo video
+- Watch on Loom: https://www.loom.com/share/e47c6ea5b1014472a3d86b6fb52dc0aa?sid=106d0a04-3d3f-4da7-9bd9-5fd8d6590858
+
 ## Core screens
 - Login
 - Driver Dashboard: trip submission, ELD submission, daily timesheet print

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -371,6 +371,10 @@ function App() {
                               <a href="https://github.com/PetitKwoba/trip_viser" target="_blank" rel="noreferrer" style={{ color: '#1976d2', textDecoration: 'underline' }}>
                                 View source on GitHub
                               </a>
+                              <span style={{ margin: '0 0.5rem', color: '#aaa' }}>|</span>
+                              <a href="https://www.loom.com/share/e47c6ea5b1014472a3d86b6fb52dc0aa?sid=106d0a04-3d3f-4da7-9bd9-5fd8d6590858" target="_blank" rel="noreferrer" style={{ color: '#1976d2', textDecoration: 'underline' }}>
+                                Watch demo (Loom)
+                              </a>
                             </div>
                           </form>
                         </div>


### PR DESCRIPTION
## Summary

- Adds Loom demo link to login UI, root README, and frontend docs for quick access to the walkthrough.
- Refactors seeding script using template helpers, role constants (with safe fallbacks), and idempotent updates to ensure consistent demo data when re-run.
- Maintains demo accounts: 3 supervisors + 20 drivers (password Test@1234).
- Fixes status rotation to cycle clearly: Active → Resting → Off Duty.

## Changes

-
-

## Screenshots / Demos (optional)

## Tests

- [x] Backend tests pass (CI)
- [ ] Frontend build passes (CI)
- [x] Added/updated tests where meaningful

## Checklist

- [x] Docs updated (README/docs/*) if behavior changed
- [x] Linked issues (e.g., closes #123)
- [x] No secrets / keys committed
2025-09-20
