### PR TITLE
chore(render): provision managed Postgres and wire DATABASE_URL; guar…

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -99,6 +99,10 @@ if any(arg in sys.argv for arg in ['test', 'pytest']) and not os.getenv('TEST_DA
 
 AUTH_USER_MODEL = 'backend.User'
 
+# Guard: avoid accidentally using SQLite in production
+if not DEBUG and DATABASES['default']['ENGINE'].endswith('sqlite3'):
+    raise RuntimeError('SQLite is not allowed when DEBUG=false. Configure DATABASE_URL or Postgres env vars.')
+
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'
 USE_I18N = True

--- a/render.yaml
+++ b/render.yaml
@@ -1,3 +1,9 @@
+databases:
+  - name: trip-viser-db
+    plan: free
+    databaseName: tripviser
+    user: tripviser
+
 services:
   - type: web
     name: trip-viser-backend
@@ -24,6 +30,8 @@ services:
       - key: ALLOWED_HOSTS
         value: "trip-viser.onrender.com"
       - key: DATABASE_URL
-        sync: false
+        fromDatabase:
+          name: trip-viser-db
+          property: connectionString
       - key: CORS_ALLOWED_ORIGINS
         value: "https://trip-viser.vercel.app"


### PR DESCRIPTION
…d against SQLite in production

## Summary

- Updated render.yaml to provision a free managed Postgres and wire DATABASE_URL automatically:
- Added a databases: block with trip-viser-db (free plan)
- Set envVars.DATABASE_URL to pull from that database using fromDatabase.connectionString
- Added a safety check in settings.py:
- If DEBUG is false and the engine is SQLite, raise a clear error instead of running and failing later
- Committed and pushed to your current branch chore/seed-23-demo-users.

## Screenshots / Demos (optional)

## Tests

- [ ] Backend tests pass (CI)
- [ ] Frontend build passes (CI)
- [ ] Added/updated tests where meaningful

## Checklist

- [ ] Docs updated (README/docs/*) if behavior changed
- [ ] Linked issues (e.g., closes #123)
- [ ] No secrets / keys committed
2025-09-20
